### PR TITLE
feat: page break

### DIFF
--- a/dappspec/_page_break.scss
+++ b/dappspec/_page_break.scss
@@ -1,0 +1,64 @@
+// Experimental
+
+h1,
+article {
+	page-break-before: always;
+}
+
+body {
+	counter-reset: h1num h2num h3num h4num figurenum;
+	padding: 0;
+	text-align: justify;
+}
+
+h1:before {
+	content: counter(h1num) '. ';
+	counter-increment: h1num;
+}
+
+h2:before {
+	content: counter(h1num) '.'counter(h2num) '. ';
+	counter-increment: h2num;
+}
+
+h3:before {
+	content: counter(h1num) '.' counter(h2num) '.'counter(h3num) '. ';
+	counter-increment: h3num;
+}
+
+h4:before {
+	content: counter(h1num) '.' counter(h2num) '.'counter(h3num) '.' counter(h4num) '. ';
+	counter-increment: h4num;
+}
+
+figcaption:before {
+	content: counter(h1num) '-' counter(figurenum) '. ';
+	counter-increment: figurenum;
+}
+
+figcaption {
+	margin: 0 auto;
+	max-width: 100%;
+	text-align: center;
+}
+
+img,
+table {
+	margin: 0 auto;
+}
+
+// Not supported by all browsers
+@page {
+	margin-bottom: 2.5cm;
+	margin-top: 2.5cm;
+}
+
+@page :left {
+	margin-left: 4cm;
+	margin-right: 3cm;
+}
+
+@page :right {
+	margin-left: 3cm;
+	margin-right: 4cm;
+}


### PR DESCRIPTION
##  Page Break:
 Provides two ways to break a page, the class break-before will to break before and break-after to break after.

Example:

```html
<!-- The title will be on a new page -->
<h1 class="break-before">My title</h1>

<p class="break-after">I will break after this paragraph</p>
<!-- Break here, the next paragraph will be on a new page -->
<p>I am on a new page</p>
````